### PR TITLE
[SENTRY-3295376765] Fixing crash while process exiting due to GenServer timeout

### DIFF
--- a/lib/journey.ex
+++ b/lib/journey.ex
@@ -89,8 +89,9 @@ defmodule Journey do
   defp call(func, %__MODULE__{} = journey, _) when is_function(func, 1) do
     try do
       func.(journey)
-    rescue
+    catch
       error -> {:error, error}
+      error,reason -> {:error, {error, reason}}
     end
   end
 

--- a/lib/journey.ex
+++ b/lib/journey.ex
@@ -90,7 +90,7 @@ defmodule Journey do
     try do
       func.(journey)
     catch
-      error -> {:error, error}
+      :error,reason -> {:error, reason}
       error,reason -> {:error, {error, reason}}
     end
   end

--- a/test/journey_test.exs
+++ b/test/journey_test.exs
@@ -31,9 +31,11 @@ defmodule JourneyTest do
         |> Journey.run(fn -> sync_step() end)
         |> Journey.run_async({__MODULE__, :async_step}, [3, :ok])
 
+      self = self()
+
       assert %Journey{steps: [sync, async], state: :running, result: nil} = journey
       assert %Step{transaction: {_, :ok}} = sync
-      assert %Step{transaction: {_, %Task{owner: self}}} = async
+      assert %Step{transaction: {_, %Task{owner: ^self}}} = async
     end
 
     test "sync step wait for async steps", %{journey: journey} do
@@ -199,6 +201,33 @@ defmodule JourneyTest do
         |> Journey.run_async({__MODULE__, :test_compensation}, [:ok, self()])
 
       error = {:error, %RuntimeError{message: "Any error"}}
+      assert %Journey{result: ^error, state: :failed, steps: steps} = result
+
+      assert [
+               %Step{
+                 transaction: {_, :ok},
+                 compensation: {_, :ok, :called}
+               },
+               %Step{
+                 transaction: {_, ^error},
+                 compensation: {_, nil, :not_called}
+               }
+             ] = steps
+
+      assert_receive :transaction_called
+      assert_receive :compensation_called
+      refute_receive :compensation_called
+    end
+
+    test "run compensation if sync transaction raise an (EXIT) exception", %{journey: journey} do
+      result =
+        journey
+        |> Journey.run_async({__MODULE__, :test_compensation}, [:ok, self()])
+        |> Journey.run({__MODULE__, :test_compensation}, [fn -> exit :timeout end, self()])
+        # Step will not add because before step will failed
+        |> Journey.run_async({__MODULE__, :test_compensation}, [:ok, self()])
+
+      error = {:error, {:exit, :timeout}}
       assert %Journey{result: ^error, state: :failed, steps: steps} = result
 
       assert [

--- a/test/journey_test.exs
+++ b/test/journey_test.exs
@@ -224,7 +224,7 @@ defmodule JourneyTest do
         journey
         |> Journey.run_async({__MODULE__, :test_compensation}, [:ok, self()])
         |> Journey.run({__MODULE__, :test_compensation}, [fn -> exit :timeout end, self()])
-        # Step will not add because before step will failed
+        # This step will not be added because previous step will have failed
         |> Journey.run_async({__MODULE__, :test_compensation}, [:ok, self()])
 
       error = {:error, {:exit, :timeout}}


### PR DESCRIPTION
In order to rescue Elixir EXIT errors, we need to use a catch clause with two params, otherwise the exception is rising above Journey and not compensating previous steps.

**Tech Reference:**
https://tylerpachal.medium.com/error-handling-in-elixir-rescue-vs-catch-946e052db97b

**SumUp Private Sentry Error:** https://sentry.io/organizations/sumup/issues/3295376765/?environment=prod&project=1838104&query=is%3Aunresolved&statsPeriod=24h

`(Sentry.CrashError ** (exit) exited in: GenServer.call( ... ** (EXIT) time out)`